### PR TITLE
fix: run RailsKeyRotator.rotated? before configuration

### DIFF
--- a/lib/rails_key_rotator/railtie.rb
+++ b/lib/rails_key_rotator/railtie.rb
@@ -4,7 +4,7 @@ require "rails"
 
 module RailsKeyRotator
   class Railtie < Rails::Railtie
-    config.before_initialize do
+    config.before_configuration do
       RailsKeyRotator.rotated?
     end
     rake_tasks do


### PR DESCRIPTION
The key needs to be rotated pretty early on (before confuguration).